### PR TITLE
Adding direct link in Support section

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,25 @@ An **Image Search** App to find **Anime** Details related to the Image. Created 
 ## Support
 
 This package currently is only tested on android and the web platform.
+<details>
+  <summary>✅ android</summary>
+  
+  1. [android-arm32.apk](https://github.com/OutdatedGuy/Whats-That-Anime/releases/download/v2.0.0/android-arm32-release.apk)
+  2. [android-arm64.apk](https://github.com/OutdatedGuy/Whats-That-Anime/releases/download/v2.0.0/android-arm64-release.apk)
+  3. [android-x86_64.apk](https://github.com/OutdatedGuy/Whats-That-Anime/releases/download/v2.0.0/android-x86_64-release.apk)
+</details>
 
-- [x] [android](https://github.com/OutdatedGuy/Whats-That-Anime/releases/download/v2.0.0/android-x86_64-release.apk)
-- [ ] ios
-- [x] [web](https://whats-that-anime.outdatedguy.rocks/)
-- [ ] windows
-- [ ] macos
-- [ ] linux
+<details>
+  <summary><a href="https://whats-that-anime.outdatedguy.rocks/">✅ web</a></summary>
+  
+  * [whats-that-anime.outdatedguy.rocks](https://whats-that-anime.outdatedguy.rocks/)
+</details> 
+
+🔳 ios <br>
+🔳 windows <br>
+🔳 macos <br>
+🔳 linux <br>
+
 
 ## Whats Next?
 

--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ This package currently is only tested on android and the web platform.
 <details>
   <summary>✅ android</summary>
   
-  + [android-arm32.apk](https://github.com/OutdatedGuy/Whats-That-Anime/releases/download/v2.0.0/android-arm32-release.apk)
-  + [android-arm64.apk](https://github.com/OutdatedGuy/Whats-That-Anime/releases/download/v2.0.0/android-arm64-release.apk)
-  + [android-x86_64.apk](https://github.com/OutdatedGuy/Whats-That-Anime/releases/download/v2.0.0/android-x86_64-release.apk)
+  - [android-arm32.apk](https://github.com/OutdatedGuy/Whats-That-Anime/releases/download/v2.0.0/android-arm32-release.apk)
+  - [android-arm64.apk](https://github.com/OutdatedGuy/Whats-That-Anime/releases/download/v2.0.0/android-arm64-release.apk)
+  - [android-x86_64.apk](https://github.com/OutdatedGuy/Whats-That-Anime/releases/download/v2.0.0/android-x86_64-release.apk)
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -33,27 +33,27 @@ An **Image Search** App to find **Anime** Details related to the Image. Created 
 - View and Manage History of all searches
 - Customize App Behaviour from Settings Page
 
-## Support
+## Platform Support
 
 This package currently is only tested on android and the web platform.
 <details>
   <summary>✅ android</summary>
   
-  1. [android-arm32.apk](https://github.com/OutdatedGuy/Whats-That-Anime/releases/download/v2.0.0/android-arm32-release.apk)
-  2. [android-arm64.apk](https://github.com/OutdatedGuy/Whats-That-Anime/releases/download/v2.0.0/android-arm64-release.apk)
-  3. [android-x86_64.apk](https://github.com/OutdatedGuy/Whats-That-Anime/releases/download/v2.0.0/android-x86_64-release.apk)
+  + [android-arm32.apk](https://github.com/OutdatedGuy/Whats-That-Anime/releases/download/v2.0.0/android-arm32-release.apk)
+  + [android-arm64.apk](https://github.com/OutdatedGuy/Whats-That-Anime/releases/download/v2.0.0/android-arm64-release.apk)
+  + [android-x86_64.apk](https://github.com/OutdatedGuy/Whats-That-Anime/releases/download/v2.0.0/android-x86_64-release.apk)
 </details>
 
 <details>
-  <summary><a href="https://whats-that-anime.outdatedguy.rocks/">✅ web</a></summary>
+  <summary>✅ <a href="https://whats-that-anime.outdatedguy.rocks/">web</a></summary>
   
-  * [whats-that-anime.outdatedguy.rocks](https://whats-that-anime.outdatedguy.rocks/)
+  - [whats-that-anime.outdatedguy.rocks](https://whats-that-anime.outdatedguy.rocks/)
 </details> 
 
-🔳 ios <br>
-🔳 windows <br>
-🔳 macos <br>
-🔳 linux <br>
+🔳 ios  
+🔳 windows  
+🔳 macos  
+🔳 linux  
 
 
 ## Whats Next?

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ An **Image Search** App to find **Anime** Details related to the Image. Created 
 
 This package currently is only tested on android and the web platform.
 
-- [x] android
+- [x] [android](https://github.com/OutdatedGuy/Whats-That-Anime/releases/download/v2.0.0/android-x86_64-release.apk)
 - [ ] ios
-- [x] web
+- [x] [web](https://whats-that-anime.outdatedguy.rocks/)
 - [ ] windows
 - [ ] macos
 - [ ] linux

--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ This package currently is only tested on android and the web platform.
 <details>
   <summary>✅ android</summary>
   
-  - [android-arm32.apk](https://github.com/OutdatedGuy/Whats-That-Anime/releases/download/v2.0.0/android-arm32-release.apk)
-  - [android-arm64.apk](https://github.com/OutdatedGuy/Whats-That-Anime/releases/download/v2.0.0/android-arm64-release.apk)
-  - [android-x86_64.apk](https://github.com/OutdatedGuy/Whats-That-Anime/releases/download/v2.0.0/android-x86_64-release.apk)
+  - [android-arm32.apk](https://github.com/OutdatedGuy/Whats-That-Anime/releases/latest/download/android-arm32-release.apk)
+  - [android-arm64.apk](https://github.com/OutdatedGuy/Whats-That-Anime/releases/latest/download/android-arm64-release.apk)
+  - [android-x86_64.apk](https://github.com/OutdatedGuy/Whats-That-Anime/releases/latest/download/android-x86_64-release.apk)
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ An **Image Search** App to find **Anime** Details related to the Image. Created 
 This package currently is only tested on android and the web platform.
 <details>
   <summary>✅ android</summary>
-  
+
   - [android-arm32.apk](https://github.com/OutdatedGuy/Whats-That-Anime/releases/latest/download/android-arm32-release.apk)
   - [android-arm64.apk](https://github.com/OutdatedGuy/Whats-That-Anime/releases/latest/download/android-arm64-release.apk)
   - [android-x86_64.apk](https://github.com/OutdatedGuy/Whats-That-Anime/releases/latest/download/android-x86_64-release.apk)
@@ -46,7 +46,7 @@ This package currently is only tested on android and the web platform.
 
 <details>
   <summary>✅ <a href="https://whats-that-anime.outdatedguy.rocks/">web</a></summary>
-  
+
   - [whats-that-anime.outdatedguy.rocks](https://whats-that-anime.outdatedguy.rocks/)
 </details> 
 


### PR DESCRIPTION
Finding a respective package for particular platform is bit tricky in Releases section. Either mention a links in Support Section or in README.md such that easy to find.
Adding a android-x86_64-release.apk link for android.

<hr>

BTW I tried this one too what's your opinion
## Support 

<details>
  <summary>✅android</summary>
  
  1. [android-arm32.apk](https://github.com/OutdatedGuy/Whats-That-Anime/releases/download/v2.0.0/android-arm32-release.apk)
  2. [android-arm64.apk](https://github.com/OutdatedGuy/Whats-That-Anime/releases/download/v2.0.0/android-arm64-release.apk)
  3. [android-x86_64.apk](https://github.com/OutdatedGuy/Whats-That-Anime/releases/download/v2.0.0/android-x86_64-release.apk)
  </details>
  
🔳 ios
✅ [web](https://whats-that-anime.outdatedguy.rocks/)
🔳 windows
🔳 macos
🔳 linux
