### PR TITLE
FIX: Link preview image not shown

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -23,12 +23,10 @@
       content="An Image Search App to find Anime Details related to the Image by using trace.moe API"
     />
 
-    <!-- Link preview image of size 1024x512 -->
-    <meta property="og:image" content="https://i.imgur.com/pwpxDni.png" />
-    <!-- Link preview image of size 1200x630 -->
-    <meta property="og:image" content="https://i.imgur.com/Je5v2sl.png" />
-    <!-- Link preview image of size 1920x1080 -->
-    <meta property="og:image" content="https://i.imgur.com/HT5c2XG.png" />
+    <!-- Social media link preview image -->
+    <meta property="og:image" content="https://i.imgur.com/2kQh4Yn.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="600" />
 
     <!-- iOS meta tags & icons -->
     <meta name="apple-mobile-web-app-capable" content="yes" />


### PR DESCRIPTION
- Using dimensions used by GitHub for image preview